### PR TITLE
DRYD-1108: Improve focus contrast for SearchResultTiles

### DIFF
--- a/styles/cspace/SearchResultTile.css
+++ b/styles/cspace/SearchResultTile.css
@@ -1,4 +1,4 @@
-@value highlightColor from '../colors.css';
+@value highlightColor, inputBorderColor from '../colors.css';
 @value searchResultTileMargin, searchResultTileWidth, searchResultTileBodyHeight from '../dimensions.css';
 
 .common {
@@ -11,6 +11,7 @@
   background-color: white;
   color: inherit;
   font-size: 0.9rem;
+  border: 1px solid inputBorderColor;
 }
 
 .common:hover {
@@ -20,6 +21,7 @@
 
 .common:focus {
   outline: none;
+  border:  1px solid highlightColor;
   box-shadow:  0 0 8px 1px highlightColor;
 }
 

--- a/styles/cspace/SearchResultTile.css
+++ b/styles/cspace/SearchResultTile.css
@@ -1,4 +1,4 @@
-@value highlightColor, inputBorderColor from '../colors.css';
+@value highlightColor from '../colors.css';
 @value searchResultTileMargin, searchResultTileWidth, searchResultTileBodyHeight from '../dimensions.css';
 
 .common {
@@ -11,7 +11,7 @@
   background-color: white;
   color: inherit;
   font-size: 0.9rem;
-  border: 1px solid inputBorderColor;
+  border: 1px solid transparent;
 }
 
 .common:hover {
@@ -21,7 +21,7 @@
 
 .common:focus {
   outline: none;
-  border:  1px solid highlightColor;
+  border: 1px solid highlightColor;
   box-shadow:  0 0 8px 1px highlightColor;
 }
 


### PR DESCRIPTION
Jira: https://collectionspace.atlassian.net/browse/CPB-8

* Add border to SearchResultTile to improve contrast on focus

# Note

I added a border to the SearchResultTile so that they don't shift when applying the border on focus

# Examples

Border:
![border](https://user-images.githubusercontent.com/894938/201424341-466ada54-0e43-4d4f-9101-aa80a4c0313b.png)

Focus:
![focus](https://user-images.githubusercontent.com/894938/201424364-d6530755-db51-4a62-96f4-7f01f4ae3e3b.png)
