### PR TITLE
CPB-7: Set background color as important

### DIFF
--- a/styles/cspace/Panel.css
+++ b/styles/cspace/Panel.css
@@ -22,7 +22,7 @@
   width: 100%;
   border: none;
   padding: 18px 42px 18px 20px;
-  background-color: inherit;
+  background-color: inherit !important;
   text-align: left;
   color: #424242;
   background-position: calc(100% - 12px) center;


### PR DESCRIPTION
Jira: https://collectionspace.atlassian.net/browse/CPB-7

* Mark background-color as important in panels

# Note

I noticed in the (MO Public Browser)[https://materialorder.org/collection/materials/search] that the panels were behaving differently compared to my local deployment. When inspecting them it appears that the wordpress theme is adding some styling on the button focus causing the issue we see. Also note that the color in question (#767676) is found only in the wp theme and not in the public browser css. 

I figured we can at least provide a way to mitigate against this by preventing the background color from changing by marking it as important. We could also set the `button:focus` to inherit its color but both produce the same result. 