### PR TITLE
Fix incorrectly specified prop type.

### DIFF
--- a/src/components/detail/ExhibitionSection.jsx
+++ b/src/components/detail/ExhibitionSection.jsx
@@ -4,7 +4,7 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import styles from '../../../styles/cspace/ExhibitionSection.css';
 
 const propTypes = {
-  exhibition: PropTypes.objectOf({
+  exhibition: PropTypes.shape({
     title: PropTypes.string,
     generalNote: PropTypes.string,
     curatorialNote: PropTypes.string,


### PR DESCRIPTION
This fixes an incorrectly specified prop type (`objectOf` instead of `shape`) that generated a warning when running in dev mode.