### PR TITLE
Add controlled material terms

### DIFF
--- a/src/config/default.js
+++ b/src/config/default.js
@@ -197,7 +197,7 @@ export default {
         }),
       },
       material: {
-        field: 'collectionobjects_common:materialGroupList.material',
+        field: 'collectionspace_denorm:materialGroupList.material',
         messages: defineMessages({
           label: {
             id: 'filter.material.label',
@@ -493,7 +493,7 @@ export default {
             defaultMessage: 'Material',
           },
         }),
-        field: 'collectionobjects_common:materialGroupList',
+        field: 'collectionspace_denorm:materialGroupList',
         format: listOf(valueAt({
           path: 'material',
           format: filterLink({}),

--- a/src/config/materials.js
+++ b/src/config/materials.js
@@ -123,6 +123,19 @@ export default {
 
   filters: {
     fields: {
+      material: {
+        field: 'collectionobjects_common:materialGroupList.material',
+        messages: defineMessages({
+          label: {
+            id: 'filter.material.label',
+            defaultMessage: 'Material',
+          },
+          shortLabel: {
+            id: 'filter.material.shortLabel',
+            defaultMessage: 'Material',
+          },
+        }),
+      },
       materialTermAttributionContributingOrganization: {
         field: 'collectionspace_denorm:holdingInstitutions.displayName',
         messages: defineMessages({
@@ -565,6 +578,19 @@ export default {
 
   detailFields: {
     fields: {
+      material: {
+        messages: defineMessages({
+          label: {
+            id: 'detailField.material.label',
+            defaultMessage: 'Material',
+          },
+        }),
+        field: 'collectionobject_common:materialGroupList',
+        format: listOf(valueAt({
+          path: 'material',
+          format: filterLink({}),
+        })),
+      },
       featuredCollectionGroupList: {
         field: 'materials_common:featuredCollectionGroupList',
         format: listOf((valueAt({

--- a/src/config/materials.js
+++ b/src/config/materials.js
@@ -569,7 +569,7 @@ export default {
   detailFields: {
     fields: {
       material: {
-        field: 'collectionobject_common:materialGroupList',
+        field: 'collectionobjects_common:materialGroupList',
       },
       featuredCollectionGroupList: {
         field: 'materials_common:featuredCollectionGroupList',

--- a/src/config/materials.js
+++ b/src/config/materials.js
@@ -125,16 +125,6 @@ export default {
     fields: {
       material: {
         field: 'collectionobjects_common:materialGroupList.material',
-        messages: defineMessages({
-          label: {
-            id: 'filter.material.label',
-            defaultMessage: 'Material',
-          },
-          shortLabel: {
-            id: 'filter.material.shortLabel',
-            defaultMessage: 'Material',
-          },
-        }),
       },
       materialTermAttributionContributingOrganization: {
         field: 'collectionspace_denorm:holdingInstitutions.displayName',
@@ -579,17 +569,7 @@ export default {
   detailFields: {
     fields: {
       material: {
-        messages: defineMessages({
-          label: {
-            id: 'detailField.material.label',
-            defaultMessage: 'Material',
-          },
-        }),
         field: 'collectionobject_common:materialGroupList',
-        format: listOf(valueAt({
-          path: 'material',
-          format: filterLink({}),
-        })),
       },
       featuredCollectionGroupList: {
         field: 'materials_common:featuredCollectionGroupList',


### PR DESCRIPTION
**What does this do?**
* Updates the material field used to get from the denormalized field

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/CB-19
Jira: https://collectionspace.atlassian.net/browse/CB-21

This is part of a set of tickets which are making updates to elasticsearch in order to store the controlled version of field names. For the material, it's now being pushed into a new index, `collectionspace_denorm:materialGroupList`.

**How should this be tested? Do these changes have associated tests?**
* Deploy the elasticsearch updates from the services branch
* Create some collection objects with controlled materials
* Verify that the controlled terms appear in the Filter list as well as the detail when selecting an object

**Dependencies for merging? Releasing to production?**
I left the old index in for the material tenant. Not sure if we want to update it or not, but that should be handled in the services layer.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally against the core tenant