### PR TITLE
CB-22: Use display name in objectProductionPlace facet in anthro config.

### DIFF
--- a/src/config/anthro.js
+++ b/src/config/anthro.js
@@ -16,6 +16,9 @@ export default {
       objectProductionPeople: {
         field: 'collectionobjects_common:objectProductionPeopleGroupList.objectProductionPeople.displayName',
       },
+      objectProductionPlace: {
+        field: 'collectionobjects_common:objectProductionPlaceGroupList.objectProductionPlace.displayName',
+      },
       taxon: {
         field: 'collectionobjects_naturalhistory_extension:taxonomicIdentGroupList.taxon.displayName',
         messages: defineMessages({


### PR DESCRIPTION
**What does this do?**

This configures the public browser for anthro to use the display name of the objectProductionPlace field for faceting, instead of the full ref name.

**Why are we doing this? (with JIRA link)**

In the anthro profile, objectProductionPlace is customized to be an authority-controlled field, instead of free text. This was causing ref names to appear as facets in the public browser.

JIRA: https://collectionspace.atlassian.net/browse/CB-22

**How should this be tested? Do these changes have associated tests?**

In the anthro public browser, the values in the Production Place facet should no longer appear as ref names (URNs).

**Dependencies for merging? Releasing to production?**

This depends on https://github.com/collectionspace/services/pull/376.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.