### PR TITLE
CB-23: Use collectionspace_denorm:objectNameList

### DIFF
--- a/src/config/default.js
+++ b/src/config/default.js
@@ -116,7 +116,7 @@ export default {
   filters: {
     fields: {
       objectName: {
-        field: 'collectionobjects_common:objectNameList.objectName',
+        field: 'collectionspace_denorm:objectNameList.objectName',
         messages: defineMessages({
           label: {
             id: 'filter.objectName.label',


### PR DESCRIPTION
**What does this do?**
Updates the field for objectName to use the denormalized value

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/CB-23

This allows the object name facet to have both controlled and uncontrolled object names can be used.

**How should this be tested? Do these changes have associated tests?**
* Run collectionspace + gateway with https://github.com/collectionspace/services/pull/377
  * Also needs updated gateway jars
* Run the public browser
* Check the object name facet has controlled and uncontrolled terms

**Dependencies for merging? Releasing to production?**
Same as with the services PR, the subtitle can be updated to no longer rely on `collectionobjects_common:objectNameList`.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter ran locally 