### PR TITLE
CB-21: Add object name to detail page.

### DIFF
--- a/src/config/default.js
+++ b/src/config/default.js
@@ -377,7 +377,7 @@ export default {
 
   detailSubtitle: (data) => {
     const {
-      'collectionobjects_common:objectNameList': objectNameGroups,
+      'collectionspace_denorm:objectNameList': objectNameGroups,
     } = data;
 
     if (objectNameGroups && objectNameGroups.length > 0) {
@@ -413,6 +413,19 @@ export default {
           },
         }),
         field: 'collectionobjects_common:objectNumber',
+      },
+      objectName: {
+        messages: defineMessages({
+          label: {
+            id: 'detailField.objectName.label',
+            defaultMessage: 'Name',
+          },
+        }),
+        field: 'collectionspace_denorm:objectNameList',
+        format: listOf(valueAt({
+          path: 'objectName',
+          format: filterLink({}),
+        })),
       },
       responsibleDepartment: {
         messages: defineMessages({
@@ -559,6 +572,7 @@ export default {
         }),
         fields: [
           'objectNumber',
+          'objectName',
           'responsibleDepartment',
         ],
       },


### PR DESCRIPTION
**What does this do?**

This adds object name (the combined controlled and uncontrolled values) to the detail page.

This also fixes controlled object name values not appearing in the subtitle.

**Why are we doing this? (with JIRA link)**

There can be multiple object names, both controlled and uncontrolled, on an object. All values are shown as filters on the search page, but there wasn't a place to see them all on the detail page.

JIRA: https://collectionspace.atlassian.net/browse/CB-21

**How should this be tested? Do these changes have associated tests?**

In CSpace, create an object with multiple names, including both controlled object names and uncontrolled object names. Publish the record to the public browser. In the public browser, locate the object, and click on it to open the detail page.

In the "Identification" section, a "Name" field should appear, containing all of the name values (both controlled and uncontrolled).

**Dependencies for merging? Releasing to production?**

This will only be compatible with CSpace 8.0, which adds a field to the ES index that combines the controlled and uncontrolled object names.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.