### PR TITLE
CB-22: Use display name in objectProductionPlace facet in bonsai config.

### DIFF
--- a/src/config/bonsai.js
+++ b/src/config/bonsai.js
@@ -11,6 +11,13 @@ export default {
     'filter.objectProductionPerson.shortLabel': 'Original artist',
     'detailField.objectProductionPerson.label': 'Original artist',
   },
+  filters: {
+    fields: {
+      objectProductionPlace: {
+        field: 'collectionobjects_common:objectProductionPlaceGroupList.objectProductionPlace.displayName',
+      },
+    },
+  },
   detailFields: {
     fields: {
       originDate: {


### PR DESCRIPTION
**What does this do?**

This configures the public browser for bonsai to use the display name of the objectProductionPlace field for faceting, instead of the full ref name.

**Why are we doing this? (with JIRA link)**

In the bonsai profile, objectProductionPlace is customized to be an authority-controlled field, instead of free text. This was causing ref names to appear as facets in the public browser.

JIRA: https://collectionspace.atlassian.net/browse/CB-22

**How should this be tested? Do these changes have associated tests?**

In the bonsai public browser, the values in the Production Place facet should no longer appear as ref names (URNs).

**Dependencies for merging? Releasing to production?**

This depends on https://github.com/collectionspace/services/pull/379.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.
