### PR TITLE
CB-24: Add detail group for rights fields

### DIFF
--- a/src/config/default.js
+++ b/src/config/default.js
@@ -564,6 +564,43 @@ export default {
         field: 'collectionspace_denorm:creditLine',
         format: list,
       },
+      rightStatement: {
+        messages: defineMessages({
+          label: {
+            id: 'detailField.rightStatement.label',
+            defaultMessage: 'Right Statement',
+          },
+        }),
+        field: 'collectionobjects_common:rightsGroupList',
+        format: listOf(valueAt({
+          path: 'rightStatement',
+        })),
+      },
+      standardizedRightStatement: {
+        messages: defineMessages({
+          label: {
+            id: 'detailField.standardizedRightStatement.label',
+            defaultMessage: 'Standardized Right Statement',
+          },
+        }),
+        field: 'collectionobjects_common:rightsGroupList',
+        format: listOf(valueAt({
+          path: 'standardizedRightStatement',
+          format: displayName,
+        })),
+      },
+      rightReproductionStatement: {
+        messages: defineMessages({
+          label: {
+            id: 'detailField.rightReproductionStatement.label',
+            defaultMessage: 'Right Reproduction Statement',
+          },
+        }),
+        field: 'collectionobjects_common:rightsInGroupList',
+        format: listOf(valueAt({
+          path: 'rightReproductionStatement',
+        })),
+      },
     },
     groups: {
       group_id: {
@@ -609,12 +646,26 @@ export default {
           'objectProductionDate',
         ],
       },
+      group_rights: {
+        messages: defineMessages({
+          label: {
+            id: 'detailGroup.group_rights.label',
+            defaultMessage: 'Rights',
+          },
+        }),
+        fields: [
+          'rightStatement',
+          'standardizedRightStatement',
+          'rightReproductionStatement',
+        ],
+      },
     },
     layout: {
       fields1: [
         'group_id',
         'group_description',
         'group_production',
+        'group_rights',
       ],
     },
   },


### PR DESCRIPTION
**What does this do?**
Adds right related fields to the detail display

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/CB-24

This updates the detail page to include additional rights information about an object.

**How should this be tested? Do these changes have associated tests?**
* Run CSpace with elasticsearch enabled and gateway deployed
* Create a collectionobject with the following fields filled out
  * Standardized right statement
  * Right statement
  * Right statement for reproduction 
* Run the public browser
* Navigate to your collectionobject details and view the detail group for right statements

**Dependencies for merging? Releasing to production?**
`anthro` and `materials` override the default layout, however when looking at them neither seem to have rights objects on their collectionobject forms. I didn't make changes to them for now as they can be easily added later if this is a mistake; I'll double check w/ Jessi about this.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@mikejritter tested locally