### PR TITLE
CB-26: Add content fields to details page

### DIFF
--- a/src/components/detail/FieldList.jsx
+++ b/src/components/detail/FieldList.jsx
@@ -18,10 +18,21 @@ const propTypes = {
   }).isRequired,
 };
 
+const aggregateData = ({ field, format }, data) => {
+  const fieldData = data[field];
+
+  return {
+    data: fieldData,
+    field,
+    format,
+  };
+};
+
 const renderField = (id, fieldConfig, data) => {
   const {
     className,
     field,
+    fields,
     format,
     label,
     messages,
@@ -32,7 +43,9 @@ const renderField = (id, fieldConfig, data) => {
     ? <FormattedMessage {...messages.label} />
     : label;
 
-  const value = data[field];
+  const value = fields
+    ? fields.map((config) => aggregateData(config, data, id))
+    : data[field];
   const formattedValue = (format && value) ? format(value, id) : value;
 
   if (!formattedValue) {

--- a/src/components/detail/FieldList.jsx
+++ b/src/components/detail/FieldList.jsx
@@ -18,16 +18,6 @@ const propTypes = {
   }).isRequired,
 };
 
-const aggregateData = ({ field, format }, data) => {
-  const fieldData = data[field];
-
-  return {
-    data: fieldData,
-    field,
-    format,
-  };
-};
-
 const renderField = (id, fieldConfig, data) => {
   const {
     className,
@@ -44,7 +34,7 @@ const renderField = (id, fieldConfig, data) => {
     : label;
 
   const value = fields
-    ? fields.map((config) => aggregateData(config, data, id))
+    ? { fields, data }
     : data[field];
   const formattedValue = (format && value) ? format(value, id) : value;
 

--- a/src/config/anthro.js
+++ b/src/config/anthro.js
@@ -137,7 +137,7 @@ export default {
         fields: [
           'material',
           'technique',
-          'contentConcept',
+          'subject',
           'measuredPart',
           'creditLine',
           'taxon',

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -10,6 +10,7 @@ import {
   listOf,
   nameRole,
   valueAt,
+  aggregate,
 } from '../helpers/formatHelpers';
 
 const departmentMessages = defineMessages({
@@ -528,6 +529,30 @@ export default {
           roleFieldName: 'techniqueType',
         })),
       },
+      subject: {
+        messages: defineMessages({
+          label: {
+            id: 'detailField.subject.label',
+            defaultMessage: 'Subject',
+          },
+        }),
+        fields: [{
+          field: 'collectionobjects_common:contentConcepts',
+          format: filterLink({ filterValueFormat: displayName }),
+        }, {
+          field: 'collectionobjects_common:contentEvents',
+          format: filterLink({ filterValueFormat: displayName }),
+        }, {
+          field: 'collectionobjects_common:contentPersons',
+          format: filterLink({ filterValueFormat: displayName }),
+        }, {
+          field: 'collectionobjects_common:contentOrganizations',
+          format: filterLink({ filterValueFormat: displayName }),
+        }, {
+          field: 'collectionobjects_common:contentDescription',
+        }],
+        format: aggregate,
+      },
       contentConcept: {
         messages: defineMessages({
           label: {
@@ -626,7 +651,7 @@ export default {
         fields: [
           'material',
           'technique',
-          'contentConcept',
+          'subject',
           'measuredPart',
           'creditLine',
         ],

--- a/src/config/fcart.js
+++ b/src/config/fcart.js
@@ -28,7 +28,7 @@ export default {
           'materialTechniqueDescription',
           'material',
           'technique',
-          'contentConcept',
+          'subject',
           'measuredPart',
           'creditLine',
         ],

--- a/src/helpers/formatHelpers.jsx
+++ b/src/helpers/formatHelpers.jsx
@@ -85,6 +85,14 @@ const renderList = (values, inline = false) => {
   return values;
 };
 
+/**
+ * Create a FieldValueList from multiple fields. This assumes that the values passed in is an
+ * Array of fields to be aggregated and the detail data which was queried.
+ *
+ * @param {Object} values the json object containing the field config and detail data
+ * @param {boolean} inline if the list should be rendered inline
+ * @returns the FieldValueList
+ */
 const renderAggregate = (values, inline = false) => {
   const {
     fields,

--- a/src/helpers/formatHelpers.jsx
+++ b/src/helpers/formatHelpers.jsx
@@ -86,18 +86,24 @@ const renderList = (values, inline = false) => {
 };
 
 const renderAggregate = (values, inline = false) => {
-  const flattened = values.flatMap((value, index) => {
+  const {
+    fields,
+    data,
+  } = values;
+
+  const flattened = fields.flatMap((fieldConfig, index) => {
     const {
-      data,
       field,
       format,
-    } = value;
-    if (!data) {
+    } = fieldConfig;
+    const fieldData = data[field];
+
+    if (!fieldData) {
       return [];
     }
 
-    if (Array.isArray(data)) {
-      return data.map((childValue, childIndex) => {
+    if (Array.isArray(fieldData)) {
+      return fieldData.map((childValue, childIndex) => {
         const key = `${field}-${childIndex}`;
         const formattedValue = format ? format(childValue, field) : childValue;
         return <li key={key}>{formattedValue}</li>;
@@ -105,7 +111,7 @@ const renderAggregate = (values, inline = false) => {
     }
 
     const key = `${field}-${index}`;
-    const formattedValue = format ? format(data, field) : data;
+    const formattedValue = format ? format(fieldData, field) : fieldData;
     return <li key={key}>{formattedValue}</li>;
   });
 

--- a/src/helpers/formatHelpers.jsx
+++ b/src/helpers/formatHelpers.jsx
@@ -85,6 +85,37 @@ const renderList = (values, inline = false) => {
   return values;
 };
 
+const renderAggregate = (values, inline = false) => {
+  const flattened = values.flatMap((value, index) => {
+    const {
+      data,
+      field,
+      format,
+    } = value;
+    if (!data) {
+      return [];
+    }
+
+    if (Array.isArray(data)) {
+      return data.map((childValue, childIndex) => {
+        const key = `${field}-${childIndex}`;
+        const formattedValue = format ? format(childValue, field) : childValue;
+        return <li key={key}>{formattedValue}</li>;
+      });
+    }
+
+    const key = `${field}-${index}`;
+    const formattedValue = format ? format(data, field) : data;
+    return <li key={key}>{formattedValue}</li>;
+  });
+
+  return (
+    <FieldValueList inline={inline}>
+      {flattened}
+    </FieldValueList>
+  );
+};
+
 export const unformatted = (data) => data;
 
 export const boolean = (value) => {
@@ -97,6 +128,8 @@ export const boolean = (value) => {
       return value;
   }
 };
+
+export const aggregate = (value) => renderAggregate(value);
 
 export const literal = (value) => () => value;
 


### PR DESCRIPTION
**What does this do?**
This adds the newly indexed fields to the subject description detail:
* Content Organization
* Content People
* Content Event
* Content Description

A new formatHelper `aggregate` has been added to assist with formatting multiple fields under a single field display.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/CB-26

For the 8.0 release, each of the fields above have been added to the Elastic index. This work makes use of the new fields and adds them into the display. It was requested that they all display under the `Subject` field, which was previously only populated by Content Concept, which was the main driver behind adding the aggregate format helper.

**How should this be tested? Do these changes have associated tests?**
* Create a CollectionObject with the following fields filled out (found under `Object Description Information` -> `Concept`):
  * contentConcept
  * contentPerson
  * contentOrganization
  * contentDescription
* Navigate to the CollectionObject detail page and see that the `Subject` field has entries from each content field.

**Dependencies for merging? Releasing to production?**
I tested this on core, but was having trouble getting other profiles to connect to their elastic indexes through the gateway. I made changes to the detail description group for other profiles where applicable so that they will get the updated fields.

These fields will also need to be added to the filter at some point, but at the moment we've decided to do this in a separate issue. Unfortunately the elastic version we use means we can't update the query to use `multi_term`, so I'm not sure if there will be an easy way to handle updating the filters. It's still tbd on how exactly to display these though.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against core