### PR TITLE
CB-26: Replace contentConcept with aggregate subject field

### DIFF
--- a/src/config/anthro.js
+++ b/src/config/anthro.js
@@ -65,7 +65,7 @@ export default {
         fields: [
           'material',
           'technique',
-          'contentConcept',
+          'subject',
           'color',
           'taxon',
         ],
@@ -137,7 +137,7 @@ export default {
         fields: [
           'material',
           'technique',
-          'contentConcept',
+          'subject',
           'measuredPart',
           'creditLine',
           'taxon',

--- a/src/config/anthro.js
+++ b/src/config/anthro.js
@@ -138,6 +138,7 @@ export default {
           'material',
           'technique',
           'subject',
+          'contentDescription',
           'measuredPart',
           'creditLine',
           'taxon',

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -252,15 +252,15 @@ export default {
           },
         }),
       },
-      contentConcept: {
-        field: 'collectionobjects_common:contentConcepts.displayName',
+      subject: {
+        field: 'collectionspace_denorm:contentSubjectList.subject',
         messages: defineMessages({
           label: {
-            id: 'filter.contentConcept.label',
+            id: 'filter.subject.label',
             defaultMessage: 'Subject',
           },
           shortLabel: {
-            id: 'filter.contentConcept.shortLabel',
+            id: 'filter.subject.shortLabel',
             defaultMessage: 'Subject',
           },
         }),
@@ -331,7 +331,7 @@ export default {
         }),
         fields: [
           'material',
-          'contentConcept',
+          'subject',
           'color',
         ],
       },
@@ -528,16 +528,17 @@ export default {
           roleFieldName: 'techniqueType',
         })),
       },
-      contentConcept: {
+      subject: {
         messages: defineMessages({
           label: {
-            id: 'detailField.contentConcept.label',
+            id: 'detailField.subject.label',
             defaultMessage: 'Subject',
           },
         }),
-        field: 'collectionobjects_common:contentConcepts',
-        format: listOf(filterLink({
-          filterValueFormat: displayName,
+        field: 'collectionspace_denorm:contentSubjectList',
+        format: listOf(valueAt({
+          path: 'subject',
+          format: filterLink({}),
         })),
       },
       measuredPart: {
@@ -626,7 +627,7 @@ export default {
         fields: [
           'material',
           'technique',
-          'contentConcept',
+          'subject',
           'measuredPart',
           'creditLine',
         ],

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -541,6 +541,15 @@ export default {
           format: filterLink({}),
         })),
       },
+      contentDescription: {
+        messages: defineMessages({
+          label: {
+            id: 'detailField.contentDescription.label',
+            defaultMessage: 'Content Description',
+          },
+        }),
+        field: 'collectionobjects_common:contentDescription',
+      },
       measuredPart: {
         messages: defineMessages({
           label: {
@@ -628,6 +637,7 @@ export default {
           'material',
           'technique',
           'subject',
+          'contentDescription',
           'measuredPart',
           'creditLine',
         ],

--- a/src/config/fcart.js
+++ b/src/config/fcart.js
@@ -29,6 +29,7 @@ export default {
           'material',
           'technique',
           'subject',
+          'contentDescription',
           'measuredPart',
           'creditLine',
         ],

--- a/src/config/fcart.js
+++ b/src/config/fcart.js
@@ -28,7 +28,7 @@ export default {
           'materialTechniqueDescription',
           'material',
           'technique',
-          'contentConcept',
+          'subject',
           'measuredPart',
           'creditLine',
         ],


### PR DESCRIPTION
**What does this do?**
Replace the contentConcept field with the denormalized contentSubjectList in order to display the content fields under a single heading.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/jira/software/c/projects/CB/issues/CB-26

We added additional fields to the index which are all related - content description, content event, content organization, and content person. It was requested to have these all display under the 'Subject' heading, along with the content concept. In order to do this we've added a denormalized field, `collectionspace_denorm:contentSubjectList` which contains the values from each field. This updates the filter and detail display so that they are pulling from the denormalized field which does the aggregation for us.

**How should this be tested? Do these changes have associated tests?**
* Using the indexed object from https://github.com/collectionspace/services/pull/394
* Run the public browser
* View the `Subject` filter and see that all the content fields are being used to populate it
* Navigate to the detail page for your collectionobject and see the content fields all display under the description `Subject` heading

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally