### PR TITLE
CB-29: Use deurned field for objectProductionPlace

### DIFF
--- a/src/config/lhmc.js
+++ b/src/config/lhmc.js
@@ -1,3 +1,11 @@
 export default {
   gatewayUrl: 'http://localhost:8180/gateway/lhmc',
+
+  filters: {
+    fields: {
+      objectProductionPlace: {
+        field: 'collectionobjects_common:objectProductionPlaceGroupList.objectProductionPlace.displayName',
+      },
+    },
+  },
 };


### PR DESCRIPTION
**What does this do?**
This updates objectProductionPlace to use the displayName field in order for the Filter facet to display deurned values.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/jira/software/c/projects/CB/issues/CB-29

For LHMC the objectProductionPlace field uses the place authority and needs to be deurned when being indexed for the public browser. This update is for the public browser so that we actually read the deurned field instead of the refname.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver with the lhmc config:
```
      cspacePublicBrowser({
       baseConfig: 'lhmc',
        gatewayUrl: 'http://localhost:8180/gateway/lhmc',
      });
```
* In the filter facet see that the object production place values are deurned
* Verify that searching using the object production place works as expected

**Dependencies for merging? Releasing to production?**
None

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally
