### PR TITLE
CB-27: Update field for numberOfObjects display

### DIFF
--- a/src/config/materials.js
+++ b/src/config/materials.js
@@ -1073,7 +1073,7 @@ export default {
         objectCount: {
           label: 'Holdings',
           field: 'collectionobjects_common:objectCountGroupList',
-          format: listOf(
+          format: inlineListOf(
             valueAt({ path: 'objectCount' }),
           ),
         },

--- a/src/config/materials.js
+++ b/src/config/materials.js
@@ -1070,9 +1070,12 @@ export default {
             linkValue: false,
           })),
         },
-        numberOfObjects: {
+        objectCount: {
           label: 'Holdings',
-          field: 'collectionobjects_common:numberOfObjects',
+          field: 'collectionobjects_common:objectCountGroupList',
+          format: listOf(
+            valueAt({ path: 'objectCount' }),
+          ),
         },
         objectStatusList: {
           label: 'Type',
@@ -1138,7 +1141,7 @@ export default {
         },
         group_sample_holdings: {
           fields: [
-            'numberOfObjects',
+            'objectCount',
             'objectStatusList',
           ],
           className: 'inline',

--- a/src/config/materials.js
+++ b/src/config/materials.js
@@ -4,6 +4,7 @@ import { getItemShortID } from 'cspace-refname';
 import {
   displayName,
   filterLink,
+  head,
   linkText,
   inlineList,
   listOf,
@@ -1073,9 +1074,7 @@ export default {
         objectCount: {
           label: 'Holdings',
           field: 'collectionobjects_common:objectCountGroupList',
-          format: inlineListOf(
-            valueAt({ path: 'objectCount' }),
-          ),
+          format: head(valueAt({ path: 'objectCount' })),
         },
         objectStatusList: {
           label: 'Type',

--- a/src/helpers/formatHelpers.jsx
+++ b/src/helpers/formatHelpers.jsx
@@ -299,6 +299,10 @@ export const paragraphs = (array) => (
   array && array.length > 0 && array.map((value, index) => <p key={index}>{value}</p>)
 );
 
+export const head = (format) => (array, fieldName) => (
+  Array.isArray(array) && array.length > 0 ? format(array[0], fieldName) : null
+);
+
 export const valueAt = (config) => (data) => {
   const {
     path,


### PR DESCRIPTION
**What does this do?**
Updates the field for numberOfObjects to use objectCountGroupList

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/jira/software/c/projects/CB/issues/CB-27

In cspace 8.0 `numberOfObjects` has been replaced with a repeating group, `objectCountGroupList`. The old value is now in `objectCount`, which this updates the detail field to read from. 

**How should this be tested? Do these changes have associated tests?**
Setting this up is _kind_ of involved, so let me know if there are any mistakes:
* Configure collectionspace to enable elasticsearch
* Configure the gateway for the material profile, e.g.
```
es:        
  allowedRecordTypes: CollectionObject,Materialitem                                                       
  recordTypes:                                                                                                         
    CollectionObject:                   
      publishToField: collectionobjects_common:publishToList.shortid
    Media:                      
      publishToField: media_common:publishToList.shortid
    Materialitem:                                 
      publishToField: materials_common:publishToList.shortid                                                         
  allowedPublishToValues: cspacepub,materialorder,all

zuul:
  routes:                              
    materials-cspace-services:
      path: /materials/cspace-services/**
      url: http://localhost:8180/cspace-services
      username: reader@materials.collectionspace.org
      password: reader
    materials-es:
      path: /materials/es/**
      url: http://localhost:9200/materials_default
```
* In the materials cspace ui profile
  * Create a local organization and note the shortid. This will act as the institution for the public browser
  * Create a material authority with the local organization as the Term creator, and set to publish to materialorder or all
  * Create a collectionobject with one or more object count fields, the above material, and set to publish to materialorder or all
* In the public browser
  * Configure the material profile with an institution, e.g.
```
    cspacePublicBrowser({                                                                                              
      baseConfig: 'materials',                             
      gatewayUrl: 'http://localhost:8180/gateway/materials',                                                           
      institutions: {                                                                                                  
        TestInstitution1710453380686: {  // This should be your created institution's shortid                                                                           
          title: 'Test Institution',                       
          gatewayUrl: 'http://localhost:8180/gateway/materials',                                                       
        },                                                                                                             
      },                                                                                                               
    });                                                                                                                
``` 
  * Run the public browser and navigate to your authority item
  * Under the 'Samples at...' panel, see the `Holdings` display for the collectionobject match the object count set from the cspace ui

**Dependencies for merging? Releasing to production?**
None, though we might want to revisit the display to see if we want to show any of the other object count group fields.

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally