### PR TITLE
Update CI Branch Name

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -2,9 +2,9 @@ name: Continuous integration
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   check:


### PR DESCRIPTION
**What does this do?**
* Update the CI Branch

**Why are we doing this? (with JIRA link)**
No Jira

I updated the default branch name to be more consistent with other projects we work on. This updates the ci config to match.