### PR TITLE
DRYD-1455: Display Related Links

### DIFF
--- a/src/config/default.js
+++ b/src/config/default.js
@@ -6,6 +6,7 @@ import {
   decade,
   displayName,
   filterLink,
+  linkText,
   list,
   listOf,
   nameRole,
@@ -619,9 +620,10 @@ export default {
           },
         }),
         field: 'collectionobjects_common:publishedRelatedLinkGroupList',
-        format: listOf(nameRole({
-          nameFieldName: 'relatedLink',
-          roleFieldName: 'descriptiveTitle',
+        format: listOf(linkText({
+          urlFieldName: 'relatedLink',
+          textFieldName: 'descriptiveTitle',
+          type: 'external',
         })),
       },
     },

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -611,6 +611,19 @@ export default {
           path: 'rightReproductionStatement',
         })),
       },
+      relatedLinks: {
+        messages: defineMessages({
+          label: {
+            id: 'detailField.relatedLinks.label',
+            defaultMessage: 'Related Links',
+          },
+        }),
+        field: 'collectionobjects_common:publishedRelatedLinkGroupList',
+        format: listOf(nameRole({
+          nameFieldName: 'relatedLink',
+          roleFieldName: 'descriptiveTitle',
+        })),
+      },
     },
     groups: {
       group_id: {
@@ -670,6 +683,17 @@ export default {
           'rightReproductionStatement',
         ],
       },
+      group_reference: {
+        messages: defineMessages({
+          label: {
+            id: 'detailGroup.group_reference.label',
+            defaultMessage: 'Reference',
+          },
+        }),
+        fields: [
+          'relatedLinks',
+        ],
+      },
     },
     layout: {
       fields1: [
@@ -677,6 +701,7 @@ export default {
         'group_description',
         'group_production',
         'group_rights',
+        'group_reference',
       ],
     },
   },


### PR DESCRIPTION
**What does this do?**
* Add reference display group
* Add related link detail

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1455

Related links are a new field which are intended to be used alongside the public browser. This adds support to the browser in order to display them.

**How should this be tested? Do these changes have associated tests?**
* Set the gateway url to core.dev
```
      gatewayUrl: 'https://core.dev.collectionspace.org/gateway/core',
```
* Run the devserver: `npm run devserver`
* Navigate to an object with related links and see that they display

**Dependencies for merging? Releasing to production?**
There's still an open question about the related link behavior which needs to be answered before merging

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested using core.dev as a backend