### PR TITLE
Link on featuredCollection; add filter for featuredApplication

### DIFF
--- a/src/config/materials.js
+++ b/src/config/materials.js
@@ -119,7 +119,7 @@ export default {
       'materials_common:description': description,
     } = data;
 
-    return [description];
+    return description;
   },
 
   filters: {

--- a/src/config/materials.js
+++ b/src/config/materials.js
@@ -119,7 +119,7 @@ export default {
       'materials_common:description': description,
     } = data;
 
-    return description;
+    return [description];
   },
 
   filters: {
@@ -454,6 +454,24 @@ export default {
           },
         }),
       },
+      featuredApplication: {
+        field: 'materials_common:featuredApplicationGroupList.featuredApplication.displayName',
+        messages: defineMessages({
+          label: {
+            id: 'filter.featuredApplication.label',
+            defaultMessage: 'Featured application',
+          },
+        }),
+      },
+      featuredCollection: {
+        field: 'materials_common:featuredCollectionGroupList.featuredCollection.displayName',
+        messages: defineMessages({
+          label: {
+            id: 'filter.featuredCollection.label',
+            defaultMessage: 'Featured collection',
+          },
+        }),
+      },
     },
     groups: {
       group_institution: {
@@ -576,7 +594,9 @@ export default {
         field: 'materials_common:featuredCollectionGroupList',
         format: listOf((valueAt({
           path: 'featuredCollection',
-          format: displayName,
+          format: filterLink({
+            filterValueFormat: displayName,
+          }),
         }))),
       },
       materialCompositionGroupList: {


### PR DESCRIPTION
**What does this do?**
* Add filter links to featured collections
* Add filter for featured collection
* Add filter for featured application 

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1456

This allows users of the public browser to use the `Featured Collection` field as a search in order to find related materials. It also fixes searching on `Featured Application` which would fail to search because a filter had not been defined. 

**How should this be tested? Do these changes have associated tests?**
* Update the index.html to use the materials config and materials.dev as a gateway
* Select one of the materials listed
* Verify that linking from the `Featured Collection` and `Featured Application` work

**Dependencies for merging? Releasing to production?**
None

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested with materials.dev as a backend