### PR TITLE
DRYD-1789: Update Config Merge 

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,5 +1,5 @@
 import loget from 'lodash/get';
-import lomerge from 'lodash/merge';
+import lomerge from 'lodash/mergeWith';
 import defaultConfig from './default';
 import anthroConfig from './anthro';
 import bonsaiConfig from './bonsai';
@@ -23,6 +23,15 @@ const namedConfig = {
 
 const config = lomerge({}, defaultConfig);
 
+const configMerge = (objValue, srcValue) => {
+  // overwrite arrays instead of merging them
+  if (Array.isArray(objValue)) {
+    return srcValue;
+  }
+
+  return undefined;
+};
+
 export default {
   get: (path, defaultValue) => loget(config, path, defaultValue),
 
@@ -39,11 +48,11 @@ export default {
         const baseConfig = namedConfig[baseConfigName];
 
         if (baseConfig) {
-          lomerge(config, baseConfig);
+          lomerge(config, baseConfig, configMerge);
         }
       }
 
-      lomerge(config, source);
+      lomerge(config, source, configMerge);
     });
   },
 

--- a/test/specs/config/index.spec.js
+++ b/test/specs/config/index.spec.js
@@ -1,0 +1,48 @@
+import config from '../../../src/config';
+
+chai.should();
+
+describe('config', () => {
+  it('should have default properties', () => {
+    const filters = config.get('filters');
+    const detailFields = config.get('detailFields');
+
+    filters.should.have.property('fields');
+    filters.should.have.property('groups');
+    filters.should.have.property('layout');
+
+    detailFields.should.have.property('fields');
+    detailFields.should.have.property('groups');
+    detailFields.should.have.property('layout');
+  });
+
+  it('should overwrite arrays during merge', () => {
+    const customConfig = {
+      filters: {
+        groups: {
+          group_production: {
+            fields: ['technique'],
+          },
+        },
+      },
+    };
+
+    config.get(['filters', 'groups', 'group_production']).should.be.an('object');
+
+    // First check the default config has an array with size > 1
+    const {
+      fields: defaultFields,
+    } = config.get(['filters', 'groups', 'group_production']);
+
+    defaultFields.should.not.have.lengthOf(1);
+
+    // Then update and check our array only contains 'technique'
+    config.merge(customConfig);
+    const {
+      fields: updatedFields,
+    } = config.get(['filters', 'groups', 'group_production']);
+
+    updatedFields.should.have.length(1);
+    updatedFields.should.include('technique');
+  });
+});


### PR DESCRIPTION
**What does this do?**
This updates the config.merge to use `mergeWith` instead of `merge` so that we can overwrite Arrays from child configs.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1789

This is something that was noticed when trying to configure the displayed filter facets and having some repeat. The repetition of the facet turned out to be a bit of a red herring in that we were merging arrays but expecting them to be overwritten which lead to unexpected behavior.

This update brings the merge logic in line with that of cspace-ui.js, but without the need to handle React elements or advancedSearch config.

**How should this be tested? Do these changes have associated tests?**
A few things should be done for testing:
* First run `npm test` to ensure the test passes
* Edit the index.html to include the following in the `cspacePublicBrowser` configuration
```
        filters: {
          groups: {
            group_production: {
              fields: [
                  'technique',
                  'prodYears',
              ],
            },
          },
        },
```
* Run the devserver (if you aren't running a gateway, you can set the url to https://core.dev.collectionspace.org/gateway/core)
* See that the `Production` filter facet only contains two filter options
* Stop the devserver and change the `baseConfig` to one of the profiles (and set the gateway url appropriately)
* See that the various filters/displays match the config

**Dependencies for merging? Releasing to production?**
None

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
No. 

**Did someone actually run this code to verify it works?**
@mikejritter tested locally by changing the index.html config