### PR TITLE
DRYD-1800: Add color to display for anthro

### DIFF
--- a/src/config/anthro.js
+++ b/src/config/anthro.js
@@ -138,6 +138,7 @@ export default {
           'material',
           'technique',
           'subject',
+          'color',
           'contentDescription',
           'measuredPart',
           'creditLine',

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -6,6 +6,7 @@ import {
   decade,
   displayName,
   filterLink,
+  inlineList,
   linkText,
   list,
   listOf,
@@ -515,6 +516,16 @@ export default {
           path: 'material',
           format: filterLink({}),
         })),
+      },
+      color: {
+        messages: defineMessages({
+          label: {
+            id: 'filter.color.label',
+            defaultMessage: 'Color',
+          },
+        }),
+        field: 'collectionobjects_common:colors',
+        format: inlineList,
       },
       technique: {
         messages: defineMessages({


### PR DESCRIPTION
**What does this do?**
Adds color to the display facet for anthro

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1800

We found it odd that color could be used as a filter, but it wasn't displayed alongside the rest of the description details. This adds it to the details.

**How should this be tested? Do these changes have associated tests?**
* In anthro: create an object with the colors filled out which is published to the public browser
* In the public browser: Navigate to the object and see the colors

**Dependencies for merging? Releasing to production?**
Materials also has colors defined as a field, we should make sure nothing broke in their browser.

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local anthro/public browser