### PR TITLE
DRYD-1455: Add reference group to all profiles

### DIFF
--- a/src/config/anthro.js
+++ b/src/config/anthro.js
@@ -152,6 +152,7 @@ export default {
         'group_collection',
         'group_description',
         'group_production',
+        'group_reference',
       ],
     },
   },

--- a/src/config/fcart.js
+++ b/src/config/fcart.js
@@ -41,6 +41,7 @@ export default {
         'group_id',
         'group_description',
         'group_rights',
+        'group_reference',
       ],
     },
   },

--- a/src/config/lhmc.js
+++ b/src/config/lhmc.js
@@ -15,6 +15,7 @@ export default {
         'group_id',
         'group_description',
         'group_rights',
+        'group_reference',
       ],
     },
   },

--- a/src/config/materials.js
+++ b/src/config/materials.js
@@ -1194,6 +1194,7 @@ export default {
           'group_sample_briefDescriptions',
           'group_sample_measuredPartGroupList',
           'group_sample_system',
+          'group_reference',
         ],
       },
     },


### PR DESCRIPTION
**What does this do?**
This updates the layouts of all profiles to include the reference group, which contains the Related Links field.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1455

When we originally added this group, we only did so to core. This adds it to all profiles.

**How should this be tested? Do these changes have associated tests?**
* Continue from the services PR
* Ideally use one of the updated profiles, e.g. anthro
```      
      cspacePublicBrowser({
        gatewayUrl: 'http://localhost:8180/gateway/anthro',
        baseConfig: 'anthro',
      });
```
* Run the devserver, e.g. `npm run devserver`
* Check that the object you created has the reference group displayed

**Dependencies for merging? Releasing to production?**
None

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally