### PR TITLE
DRYD-1764: Retain Line Breaks

### DIFF
--- a/src/config/default.js
+++ b/src/config/default.js
@@ -11,6 +11,8 @@ import {
   list,
   listOf,
   nameRole,
+  paragraphs,
+  split,
   valueAt,
 } from '../helpers/formatHelpers';
 
@@ -561,6 +563,9 @@ export default {
           },
         }),
         field: 'collectionobjects_common:contentDescription',
+        format: split({
+          format: paragraphs,
+        }),
       },
       measuredPart: {
         messages: defineMessages({

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -402,7 +402,7 @@ export default {
     } = data;
 
     if (briefDescriptions && briefDescriptions.length > 0) {
-      return briefDescriptions;
+      return briefDescriptions.flatMap((desc) => desc.split('\n'));
     }
 
     return [];

--- a/src/config/materials.js
+++ b/src/config/materials.js
@@ -119,7 +119,7 @@ export default {
       'materials_common:description': description,
     } = data;
 
-    return description;
+    return description && description.split('\n');
   },
 
   filters: {

--- a/src/helpers/formatHelpers.jsx
+++ b/src/helpers/formatHelpers.jsx
@@ -294,9 +294,17 @@ export const numericRange = (config) => (data) => {
   ], qualifierSeparator);
 };
 
+/**
+ * Create a paragraph element for each String in an array. If the String contains a newline, it will
+ * be split in order to retain line breaks in that display.
+ *
+ * @param {} array
+ * @returns
+ */
 export const paragraphs = (array) => (
+  array && array.length > 0
   // eslint-disable-next-line react/no-array-index-key
-  array && array.length > 0 && array.map((value, index) => <p key={index}>{value}</p>)
+  && array.flapMap((value) => value.split('\n')).map((value, index) => <p key={index}>{value}</p>)
 );
 
 export const head = (format) => (array, fieldName) => (

--- a/src/helpers/formatHelpers.jsx
+++ b/src/helpers/formatHelpers.jsx
@@ -303,7 +303,7 @@ export const numericRange = (config) => (data) => {
  */
 export const paragraphs = (array) => (
   // eslint-disable-next-line react/no-array-index-key
-  array && Array.isArray(array) && array.length > 1 && array.map((value, index) => <p key={index}>{value}</p>)
+  Array.isArray(array) && array.flatMap((value) => value.split('\n')).map((value, index) => <p key={index}>{value}</p>)
 );
 
 /**

--- a/src/helpers/formatHelpers.jsx
+++ b/src/helpers/formatHelpers.jsx
@@ -302,10 +302,28 @@ export const numericRange = (config) => (data) => {
  * @returns
  */
 export const paragraphs = (array) => (
-  array && array.length > 0
   // eslint-disable-next-line react/no-array-index-key
-  && array.flapMap((value) => value.split('\n')).map((value, index) => <p key={index}>{value}</p>)
+  array && Array.isArray(array) && array.length > 1 && array.map((value, index) => <p key={index}>{value}</p>)
 );
+
+/**
+ * Split a string based on a given character to split with. Defaults to newline.
+ *
+ * @param {*} config
+ * @returns
+ */
+export const split = (config) => (string) => {
+  const {
+    splitter = '\n',
+    format = unformatted,
+  } = config;
+
+  if (!(typeof string === 'string' || string instanceof String)) {
+    return null;
+  }
+
+  return format(string.split(splitter));
+};
 
 export const head = (format) => (array, fieldName) => (
   Array.isArray(array) && array.length > 0 ? format(array[0], fieldName) : null


### PR DESCRIPTION
**What does this do?**
This updates formatting logic to retain line breaks by splitting strings on any newline found. This allows each part of the string to be wrapped in a paragraph tag in order to display each separately.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1764

This was a request put in because although many of these fields are repeating, some users use them different so we want to accommodate different use cases.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver, e.g. `npm run devserver`
* Navigate to the `Published Item New Line Test`
* See that the description (which has 2 values on core.dev) displays on 3 different lines
  * You can also inspect the response of the `_msearch` request and search for the returned `collectionobjects_common:briefDescriptions` array
* The same can be done for content description

**Dependencies for merging? Releasing to production?**
Testing should be done for other profiles as well. I did some by updating the index.html to point to materials.dev.collectionspace.org, which worked as expected.

The `flapMap` call in `paragraphs` can be redundant at times, but given the size of the data is fairly small it should be a negligible hit. I wanted to update the logic to skip it when it isn't needed, but I don't think that's necessary at this time.

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against core.dev and materials.dev