### PR TITLE
DRYD-1812: Navigate from direct link

### DIFF
--- a/src/components/detail/DetailNavBar.jsx
+++ b/src/components/detail/DetailNavBar.jsx
@@ -10,7 +10,7 @@ import styles from '../../../styles/cspace/DetailNavBar.css';
 import linkStyles from '../../../styles/cspace/Link.css';
 
 const propTypes = {
-  params: PropTypes.instanceOf(Immutable.Map).isRequired,
+  params: PropTypes.instanceOf(Immutable.Map),
   prev: PropTypes.shape({
     'ecm:name': PropTypes.string,
   }),
@@ -20,6 +20,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  params: Immutable.Map(),
   prev: undefined,
   next: undefined,
 };
@@ -39,71 +40,42 @@ const messages = defineMessages({
   },
 });
 
-export default function DetailNavBar(props) {
-  const {
-    params,
-    prev,
-    next,
-  } = props;
+export default function DetailNavBar({ params, prev, next }) {
+  function renderLink(searchParams, index, adjacent, className, message) {
+    const detailPath = config.get('detailPath');
+    const csid = get(adjacent, 'ecm:name');
 
-  const index = params.get('index');
-  const searchParams = params.get('searchParams');
-
-  if (!searchParams || typeof index === 'undefined') {
-    return null;
+    return (
+      <span>
+        <Link
+          className={className}
+          to={{
+            pathname: `/${detailPath}/${csid}`,
+            state: {
+              index,
+              searchParams,
+            },
+          }}
+        >
+          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+          <FormattedMessage {...message} />
+        </Link>
+      </span>
+    );
   }
-
-  const searchParamsObj = searchParams.toJS();
-  const detailPath = config.get('detailPath');
 
   let prevLink;
   let nextLink;
+  let queryString = '';
 
-  if (prev) {
-    const csid = get(prev, 'ecm:name');
-
-    prevLink = (
-      <span>
-        <Link
-          className={linkStyles.prev}
-          to={{
-            pathname: `/${detailPath}/${csid}`,
-            state: {
-              index: index - 1,
-              searchParams: searchParamsObj,
-            },
-          }}
-        >
-          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-          <FormattedMessage {...messages.prev} />
-        </Link>
-      </span>
-    );
+  const index = params.get('index');
+  const searchParams = params.get('searchParams');
+  if (searchParams && index !== undefined) {
+    const searchParamsObj = searchParams.toJS();
+    prevLink = prev && renderLink(searchParamsObj, index - 1, prev, linkStyles.prev, messages.prev);
+    nextLink = next && renderLink(searchParamsObj, index + 1, next, linkStyles.next, messages.next);
+    queryString = searchParamsToQueryString(searchParams);
   }
-
-  if (next) {
-    const csid = get(next, 'ecm:name');
-
-    nextLink = (
-      <span>
-        <Link
-          className={linkStyles.next}
-          to={{
-            pathname: `/${detailPath}/${csid}`,
-            state: {
-              index: index + 1,
-              searchParams: searchParamsObj,
-            },
-          }}
-        >
-          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-          <FormattedMessage {...messages.next} />
-        </Link>
-      </span>
-    );
-  }
-
-  const queryString = searchParamsToQueryString(searchParams);
 
   return (
     <nav className={styles.common}>

--- a/test/specs/components/detail/DetailNavBar.spec.jsx
+++ b/test/specs/components/detail/DetailNavBar.spec.jsx
@@ -1,0 +1,31 @@
+/* global document */
+import React from 'react';
+import { render } from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { MemoryRouter } from 'react-router';
+import { IntlProvider } from 'react-intl';
+import DetailNavBar from '../../../../src/components/detail/DetailNavBar';
+import styles from '../../../../styles/cspace/DetailNavBar.css';
+
+chai.should();
+
+describe('DetailNavBar', () => {
+  it('should render without search params', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    act(() => {
+      render(
+        <IntlProvider locale="en">
+          <MemoryRouter>
+            <DetailNavBar />
+          </MemoryRouter>
+        </IntlProvider>,
+        container,
+      );
+    });
+
+    container.firstElementChild.nodeName.should.equal('NAV');
+    container.firstElementChild.className.should.equal(styles.common);
+  });
+});


### PR DESCRIPTION
**What does this do?**
This updates the DetailNavBar so that it will render when search params don't exist on a request.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1812

This was noticed while testing various scenarios in the public browser, and is an oversight which impacts usability of the browser from different uses. In this scenario, it would be difficult to get back to the main search page because no navigation elements are rendering.

**How should this be tested? Do these changes have associated tests?**
It's probably easiest to test this running the dev server:
* `npm run devserver`
  * With the default settings, this will use the gateway for core.dev.collectionspace.org
* Navigate directly to http://localhost:8081/detail/4fb6a633-31bb-4c10-8903
  * This should render navigation elements

I added a single test for this as well which can be used:
* `npm run test`

**Dependencies for merging? Releasing to production?**
None

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**

**Did someone actually run this code to verify it works?**
@mikejritter tested using core.dev