### PR TITLE
Style Tweaks

### DIFF
--- a/styles/cspace/DetailPanel.css
+++ b/styles/cspace/DetailPanel.css
@@ -67,16 +67,3 @@ and (max-width: 839px) {
     grid-template-columns: auto 360px;
   }
 }
-
-.description > p {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.description > p:first-child {
-  margin-top: 16px;
-}
-
-.description > p:last-child {
-  margin-bottom: 16px;
-}

--- a/styles/cspace/RootPage.css
+++ b/styles/cspace/RootPage.css
@@ -25,11 +25,15 @@ a:focus {
 }
 
 p {
-  margin: 16px 0;
+  margin: 0;
 }
 
 p:first-child {
-  margin-top: 0;
+  margin-top: 16px;
+}
+
+p:last-child {
+  margin-bottom: 16px;
 }
 
 input {


### PR DESCRIPTION
**What does this do?**
* Sets styling for `<p>` tags 

**Why are we doing this? (with JIRA link)**
Related to: https://collectionspace.atlassian.net/browse/DRYD-1764

After the update to retain line breaks, we noticed inconsistency in the display for the few places where multiple lines are displayed. After some brief discussion we decided to use no top/bottom margin when displaying multiple <p> elements together..

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Navigate to the `Published Item New Line Test`
* See that the brief description and content description fields are the same

**Dependencies for merging? Releasing to production?**
None

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally