### PR TITLE
DRYD-1818: Implement image ordering functionality for public browser

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -57,3 +57,13 @@ Overrides the top-level [`filterOrder`](#filterOrder) setting, for this field.
 
 #### `size`
 Overrides the top-level [`filterSize`](#filterSize) setting, for this field.
+
+### `mediaSnapshotSort`
+Contains configuration for sorting images in object details view. The options are: `'identificationNumber'`, `'title'`, `'updatedAt'`.
+
+Default:
+```
+mediaSnapshotSort: {
+    title: 'asc',
+},
+```

--- a/src/actions/mediaActions.js
+++ b/src/actions/mediaActions.js
@@ -41,12 +41,13 @@ export const findMedia = (referenceValue, institutionId) => (dispatch, getState)
   }
 
   const url = `${gatewayUrl}/es/doc/_search`;
+  const referenceField = config.get('referenceField');
 
   const sortField = Object.keys(config.get('mediaSnapshotSort'))[0];
   const sortDirection = config.get('mediaSnapshotSort')[sortField];
 
   const query = {
-    _source: ['media_common:blobCsid', 'media_common:altText'],
+    _source: [referenceField, 'media_common:altText'],
     query: {
       terms: {
         'collectionspace_denorm:objectCsid': [referenceValue],
@@ -66,7 +67,7 @@ export const findMedia = (referenceValue, institutionId) => (dispatch, getState)
     .then((response) => response.json())
     .then((data) => {
       const hits = get(data, ['hits', 'hits'], []);
-      const mediaCsids = hits.map((hit) => get(hit, ['_source', 'media_common:blobCsid'], ''));
+      const mediaCsids = hits.map((hit) => get(hit, ['_source', referenceField], ''));
       const mediaAltTexts = hits.map((hit) => get(hit, ['_source', 'media_common:altText'], ''));
 
       return dispatch(setMedia(referenceValue, institutionId, mediaCsids, mediaAltTexts));

--- a/src/actions/mediaActions.js
+++ b/src/actions/mediaActions.js
@@ -8,10 +8,16 @@ import {
   SET_MEDIA,
 } from '../constants/actionCodes';
 
-export const setMedia = (referenceValue, institutionId, mediaCsids, mediaAltTexts, title) => ({
+// TODO: this should not be hardcoded here. Check deriving from plugin or shared lib
+const sortParams = {
+  updatedAt: 'collectionspace_core:updatedAt',
+  identificationNumber: 'media_common:identificationNumber',
+  title: 'media_common:title',
+};
+
+export const setMedia = (referenceValue, institutionId, mediaCsids, mediaAltTexts) => ({
   type: SET_MEDIA,
   payload: {
-    title,
     csids: mediaCsids,
     altTexts: mediaAltTexts,
   },
@@ -37,15 +43,19 @@ export const findMedia = (referenceValue, institutionId) => (dispatch, getState)
   const url = `${gatewayUrl}/es/doc/_search`;
   const referenceField = config.get('referenceField');
 
+  const sortParam = sortParams[config.get('mediaSnapshotSort')];
+  const sortDirection = config.get('mediaSnapshotSortDirection');
   const query = {
-    _source: ['collectionspace_denorm:mediaCsid', 'collectionspace_denorm:mediaAltText', 'collectionspace_denorm:title'],
+    _source: [referenceField, 'media_common:altText'],
     query: {
-      term: {
-        [referenceField]: referenceValue,
+      terms: {
+        'collectionspace_denorm:objectCsid': [referenceValue],
       },
     },
-    size: 1,
-    terminate_after: 1,
+    sort: {
+      [sortParam]: sortDirection,
+    },
+    size: 10000, // TODO: check if we should use scroll API instead of hardcoding the size
   };
 
   return fetch(url, {
@@ -55,11 +65,10 @@ export const findMedia = (referenceValue, institutionId) => (dispatch, getState)
   })
     .then((response) => response.json())
     .then((data) => {
-      const source = get(data, ['hits', 'hits', 0, '_source']);
-      const title = get(source, 'collectionspace_denorm:title');
-      const mediaCsids = get(source, 'collectionspace_denorm:mediaCsid') || [];
-      const mediaAltTexts = get(source, 'collectionspace_denorm:mediaAltText') || [];
+      const hits = get(data, ['hits', 'hits'], []);
+      const mediaCsids = hits.map((hit) => get(hit, ['_source', referenceField], ''));
+      const mediaAltTexts = hits.map((hit) => get(hit, ['_source', 'media_common:altText'], ''));
 
-      return dispatch(setMedia(referenceValue, institutionId, mediaCsids, mediaAltTexts, title));
+      return dispatch(setMedia(referenceValue, institutionId, mediaCsids, mediaAltTexts));
     });
 };

--- a/src/actions/mediaActions.js
+++ b/src/actions/mediaActions.js
@@ -41,20 +41,19 @@ export const findMedia = (referenceValue, institutionId) => (dispatch, getState)
   }
 
   const url = `${gatewayUrl}/es/doc/_search`;
-  const referenceField = config.get('referenceField');
 
-  const sortParam = sortParams[Object.keys(config.get('mediaSnapshotSort'))[0]];
-  const sortDirection = config.get('mediaSnapshotSort')[sortParam];
+  const sortField = Object.keys(config.get('mediaSnapshotSort'))[0];
+  const sortDirection = config.get('mediaSnapshotSort')[sortField];
 
   const query = {
-    _source: [referenceField, 'media_common:altText'],
+    _source: ['media_common:blobCsid', 'media_common:altText'],
     query: {
       terms: {
         'collectionspace_denorm:objectCsid': [referenceValue],
       },
     },
     sort: {
-      [sortParam]: sortDirection,
+      [sortParams[sortField]]: sortDirection,
     },
     size: 10000, // TODO: check if we should use scroll API instead of hardcoding the size
   };
@@ -67,7 +66,7 @@ export const findMedia = (referenceValue, institutionId) => (dispatch, getState)
     .then((response) => response.json())
     .then((data) => {
       const hits = get(data, ['hits', 'hits'], []);
-      const mediaCsids = hits.map((hit) => get(hit, ['_source', referenceField], ''));
+      const mediaCsids = hits.map((hit) => get(hit, ['_source', 'media_common:blobCsid'], ''));
       const mediaAltTexts = hits.map((hit) => get(hit, ['_source', 'media_common:altText'], ''));
 
       return dispatch(setMedia(referenceValue, institutionId, mediaCsids, mediaAltTexts));

--- a/src/actions/mediaActions.js
+++ b/src/actions/mediaActions.js
@@ -43,8 +43,9 @@ export const findMedia = (referenceValue, institutionId) => (dispatch, getState)
   const url = `${gatewayUrl}/es/doc/_search`;
   const referenceField = config.get('referenceField');
 
-  const sortParam = sortParams[config.get('mediaSnapshotSort')];
-  const sortDirection = config.get('mediaSnapshotSortDirection');
+  const sortParam = sortParams[Object.keys(config.get('mediaSnapshotSort'))[0]];
+  const sortDirection = config.get('mediaSnapshotSort')[sortParam];
+
   const query = {
     _source: [referenceField, 'media_common:altText'],
     query: {

--- a/src/components/detail/ImageGallery.jsx
+++ b/src/components/detail/ImageGallery.jsx
@@ -17,12 +17,16 @@ const propTypes = {
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
   media: PropTypes.instanceOf(Immutable.Map),
+  detailData: PropTypes.shape({
+    'collectionobjects_common:titleGroupList': PropTypes.array,
+  }),
   referenceValue: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
   institutionId: undefined,
   media: undefined,
+  detailData: undefined,
   findMedia: () => undefined,
 };
 
@@ -97,6 +101,7 @@ class ImageGallery extends Component {
       institutionId,
       intl,
       media,
+      detailData,
     } = this.props;
 
     if (!media) {
@@ -111,9 +116,11 @@ class ImageGallery extends Component {
 
     institutionIds.forEach((instId) => {
       const mediaMap = media.get(instId) || Immutable.Map();
-      const title = mediaMap.get('title');
       const mediaCsids = mediaMap.get('csids') || Immutable.List();
       const mediaAltTexts = mediaMap.get('altTexts') || Immutable.List();
+
+      const titleFormatter = config.get('detailTitle');
+      const title = titleFormatter && titleFormatter(detailData);
 
       if (mediaCsids && mediaCsids.size > 0) {
         const gatewayUrl = instId

--- a/src/components/detail/ImageGalleryContainer.js
+++ b/src/components/detail/ImageGalleryContainer.js
@@ -1,10 +1,11 @@
 import { connect } from 'react-redux';
 import ImageGallery from './ImageGallery';
 import { findMedia } from '../../actions/mediaActions';
-import { getMedia } from '../../reducers';
+import { getDetailData, getMedia } from '../../reducers';
 
 const mapStateToProps = (state, ownProps) => ({
   media: getMedia(state, ownProps.referenceValue),
+  detailData: getDetailData(state),
 });
 
 const mapDispatchToProps = {

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -109,6 +109,9 @@ export default {
   sortField: 'collectionspace_denorm:title',
   storageKey: 'cspace-browser',
 
+  mediaSnapshotSort: 'updatedAt',
+  mediaSnapshotSortDirection: 'desc',
+
   searchResultImageDerivative: 'Small',
   detailImageDerivative: 'Medium',
 

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -109,8 +109,9 @@ export default {
   sortField: 'collectionspace_denorm:title',
   storageKey: 'cspace-browser',
 
-  mediaSnapshotSort: 'updatedAt',
-  mediaSnapshotSortDirection: 'desc',
+  mediaSnapshotSort: {
+    title: 'asc',
+  },
 
   searchResultImageDerivative: 'Small',
   detailImageDerivative: 'Medium',

--- a/src/reducers/mediaReducer.js
+++ b/src/reducers/mediaReducer.js
@@ -8,7 +8,6 @@ const setMedia = (state, action) => {
   const {
     csids,
     altTexts,
-    title,
   } = action.payload;
 
   const {
@@ -21,7 +20,6 @@ const setMedia = (state, action) => {
     Immutable.fromJS({
       csids,
       altTexts,
-      title,
     }),
   );
 };


### PR DESCRIPTION
**What does this do?**
* Changed query for getting medias from searching objects to searching medias filtered by object id and sorted by sort param.
* The sorting is configurable.
* Changed storing title in state when quering for medias. Set using the already existing title in state for images alt text.

**Why are we doing this? (with JIRA link)**
We need to be able to search for medias, filtered by related objects and sorted by updatedAt, identificationNumber or title. https://collectionspace.atlassian.net/browse/DRYD-1818

**How should this be tested? Do these changes have associated tests?**
First you need to deploy services application after checking out https://github.com/collectionspace/services/pull/479.
Then in public browser:
1. Open a detail view of an object
2. Check that the images in the gallery are sorted according to the sorting configuration
3. Check that for images without alt text set, the object title (if existing) is being used for alt text

**Dependencies for merging? Releasing to production?**
The 
https://github.com/collectionspace/services/pull/479 
https://github.com/collectionspace/cspace-public-gateway/pull/33
should be first merged and released.

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
No, only the dev documentation has been updated. We should decide if it makes sense to create links from wiki documentation to the github ones.

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally