### PR TITLE
DRYD-1830: Public Browser > Exhibition Breaks Brief Description Formatting

### DIFF
--- a/src/components/detail/DetailPanel.jsx
+++ b/src/components/detail/DetailPanel.jsx
@@ -214,11 +214,13 @@ export default class DetailPanel extends Component {
       <div className={styles.common}>
         {this.renderPageTitle()}
         {this.renderHeader()}
-        {this.renderDescription()}
-        {this.renderImageGallery()}
-        {this.renderFieldList()}
-        {this.renderInstitutions()}
-        {this.renderExhibition()}
+        <main>
+          {this.renderDescription()}
+          {this.renderImageGallery()}
+          {this.renderFieldList()}
+          {this.renderInstitutions()}
+          {this.renderExhibition()}
+        </main>
       </div>
     );
   }

--- a/src/components/detail/DetailPanel.jsx
+++ b/src/components/detail/DetailPanel.jsx
@@ -214,13 +214,11 @@ export default class DetailPanel extends Component {
       <div className={styles.common}>
         {this.renderPageTitle()}
         {this.renderHeader()}
-        <main>
-          {this.renderDescription()}
-          {this.renderImageGallery()}
-          {this.renderFieldList()}
-          {this.renderInstitutions()}
-          {this.renderExhibition()}
-        </main>
+        {this.renderDescription()}
+        {this.renderImageGallery()}
+        {this.renderFieldList()}
+        {this.renderInstitutions()}
+        {this.renderExhibition()}
       </div>
     );
   }

--- a/styles/cspace/DetailPanel.css
+++ b/styles/cspace/DetailPanel.css
@@ -12,7 +12,7 @@
     "fields1 fields2"
     "inst inst"
     "exh exh";
-margin-left: auto;
+  margin-left: auto;
   margin-right: auto;
   max-width: 840px;
   box-sizing: border-box;

--- a/styles/cspace/DetailPanel.css
+++ b/styles/cspace/DetailPanel.css
@@ -8,11 +8,11 @@
   grid-template-areas:
     "header header"
     "desc desc"
-    "exh exh"
     "fields1 gallery"
     "fields1 fields2"
-    "inst inst";
-  margin-left: auto;
+    "inst inst"
+    "exh exh";
+margin-left: auto;
   margin-right: auto;
   max-width: 840px;
   box-sizing: border-box;

--- a/styles/cspace/DetailPanel.css
+++ b/styles/cspace/DetailPanel.css
@@ -8,6 +8,7 @@
   grid-template-areas:
     "header header"
     "desc desc"
+    "exh exh"
     "fields1 gallery"
     "fields1 fields2"
     "inst inst";

--- a/styles/cspace/ExhibitionSection.css
+++ b/styles/cspace/ExhibitionSection.css
@@ -1,6 +1,6 @@
 .common {
   grid-column: 1 / span 3;
-  margin-top: 30px;
+  grid-area: exh;
 }
 
 .common div {


### PR DESCRIPTION
**What does this do?**
It fixes the exhibition section by using the `grid-area` css rule. The section is shown at the bottom of the page.

**Why are we doing this? (with JIRA link)**
The current layout is broken when the exhibition section is shown in the details: https://collectionspace.atlassian.net/browse/DRYD-1830 

**How should this be tested? Do these changes have associated tests?**
Run public browser locally and check the details of an object with a related published exhibition. The exhibition info (Object Story, Donor Story, and Curatorial Story) should be shown under the main object record components with a divider after the main record and before these details. 

**Dependencies for merging? Releasing to production?**
No dependencies for merging.

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
No, let us check if we need to update before the release.

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally.

**Have any new accessibility violations been handled?**
no new accessibility violations introduced