### PR TITLE
DRYD-1811: Public Browser > Filter Facet Can Fail to Render

### DIFF
--- a/src/components/pages/SearchPage.jsx
+++ b/src/components/pages/SearchPage.jsx
@@ -137,10 +137,12 @@ class SearchPage extends Component {
             onClick={this.handleToggleFilterPanelButtonClick}
           />
 
-          <FilterPanel
-            api={this.handleFilterPanelApi}
-            isExpanded={isFilterPanelExpanded}
-          />
+          <aside>
+            <FilterPanel
+              api={this.handleFilterPanelApi}
+              isExpanded={isFilterPanelExpanded}
+            />
+          </aside>
         </Fixed>
 
         <SearchResultPanel

--- a/src/components/search/result/FilterPanel.jsx
+++ b/src/components/search/result/FilterPanel.jsx
@@ -28,6 +28,10 @@ const messages = defineMessages({
     id: 'FilterPanel.title',
     defaultMessage: 'Refine results:',
   },
+  noFiltersCanBeApplied: {
+    id: 'FilterPanel.noFiltersCanBeApplied',
+    defaultMessage: 'No filters can be applied',
+  },
 });
 
 const {
@@ -95,7 +99,7 @@ export default class FilterPanel extends Component {
 
     const isVisible = (window.innerWidth > filterPanelCutoffWidth) || isExpanded;
 
-    if (!isVisible || !result.get('total')) {
+    if (!isVisible) {
       return undefined;
     }
 
@@ -106,11 +110,20 @@ export default class FilterPanel extends Component {
           <FormattedMessage {...messages.title} />
         </header>
 
-        <FilterList
-          aggregations={result.get('aggregations')}
-          config={config.get('filters')}
-          isPending={isPending}
-        />
+        {
+          !result.get('total') ? (
+            <div className={styles.p20}>
+              {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+              <FormattedMessage {...messages.noFiltersCanBeApplied} />
+            </div>
+          ) : (
+            <FilterList
+              aggregations={result.get('aggregations')}
+              config={config.get('filters')}
+              isPending={isPending}
+            />
+          )
+        }
       </div>
     );
   }

--- a/styles/cspace/FilterPanel.css
+++ b/styles/cspace/FilterPanel.css
@@ -20,6 +20,10 @@
   transition: padding 0.3s;
 }
 
+.p20 {
+  padding: 0 20px;
+}
+
 .collapsed {
   composes: common;
 }


### PR DESCRIPTION
**What does this do?**
It adds showing a "No filters can be applied" message when there are no search results. It also fixes an accessibility issue by wrapping the sidebar with the aside landmark.

**Why are we doing this? (with JIRA link)**
This improves the UX of the filter sidebar. More specifically instead of showing an empty sidebar when there are no search results, we show the relevant wording: https://collectionspace.atlassian.net/browse/DRYD-1811

**How should this be tested? Do these changes have associated tests?**
Please make a search or apply a set of filters with no search results. Confirm that in that case the "No filters can be applied" wording is shown in the sidebar, instead of the empty sidebar.

**Dependencies for merging? Releasing to production?**
No dependencies for merging.

**Has the [public browser documentation]
No need to update the documentation

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally.

**Have any new accessibility violations been handled?**
Yes, the "All page content should be contained by landmarks" 4.11 has been handled.
