### PR TITLE
DRYD-1615: Public Browser > Lyrasis Hosting version of browser is different from default version

### DIFF
--- a/styles/cspace/DetailPanel.css
+++ b/styles/cspace/DetailPanel.css
@@ -31,7 +31,7 @@
 }
 
 .common p:empty {
-  padding-bottom: 1.75em;
+  padding-bottom: 1em;
 }
 
 .common :global(.cspace-ImageGallery--common) {

--- a/styles/cspace/DetailPanel.css
+++ b/styles/cspace/DetailPanel.css
@@ -30,10 +30,15 @@
   grid-area: desc;
 }
 
+.common p:empty {
+  padding-bottom: 1.75em;
+}
+
 .common :global(.cspace-ImageGallery--common) {
   grid-area: gallery;
 }
 
+.common p,
 .common h1,
 .common h2 {
   margin: 0;


### PR DESCRIPTION
**What does this do?**
It adds a padding-bottom to empty `p` elements (empty new lines).

**Why are we doing this? (with JIRA link)**
NIST hosted version (https://nistmuseum.collectionspace.org/cspace/nistmuseum/public/detail/cf972a09-0c55-4811-8f7f) looks like this: 
<img width="455" height="800" alt="image" src="https://github.com/user-attachments/assets/d4f6df12-6447-4669-9b06-2891ba4d54c2" />

while this WP version https://collectionspace.org/collection/nist_test/detail/cf972a09-0c55-4811-8f7f/ looks like this:
<img width="489" height="830" alt="image" src="https://github.com/user-attachments/assets/9babdc00-980c-4f5d-822d-d46f213dcefa" />

NIST signed off on the improvement after being shown the WP version one.

**How should this be tested? Do these changes have associated tests?**
1. Using https://core.dev.collectionspace.org/ create a new collection object.
2. Set its brief description to something that contains empty new lines. Like this:
```
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tincidunt facilisis posuere. Pellentesque non porttitor ligula. Suspendisse potenti. Duis lobortis pellentesque auctor. 

Mauris porta nunc ultrices congue pellentesque. Mauris pellentesque finibus risus, id facilisis libero tempus ut. Integer a odio vel urna pharetra ultrices. 
```
3. Set "Publish to" field to "All"
4. Run public browser locally using core.dev as backend
5. Navigate to the detail view of the just created object and confirm that paragraphs are visually divided. Like this:
<img width="895" height="866" alt="image" src="https://github.com/user-attachments/assets/c26fa85a-f01f-45fa-8991-82d5a48a631d" />



**Dependencies for merging? Releasing to production?**
No dependencies

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
No need

**Did someone actually run this code to verify it works?**
@spirosdi ran this locally using core.dev as backend.

**Have any new accessibility violations been handled?**
[Check browser console for any accessibility (axe) violations introduced and describe how they have been handled]
No new accessibility violations introduced
