### PR TITLE
Release 3.5.0-rc1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v3.5.0
+- Add configurable image ordering (default: updated-at descending)
+- Fix exhibition layout issue
+- Improve filter sidebar UX
+- Fix paragraph padding
+
 ## v3.3.0
 
 - Display all brief descriptions when available

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@collectionspace/cspace-public-browser",
-  "version": "3.4.0",
+  "version": "3.5.0-rc1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@collectionspace/cspace-public-browser",
-  "version": "3.4.0",
+  "version": "3.5.0-rc1.0",
   "description": "CollectionSpace public browser",
   "author": "Ray Lee <ray.lee@lyrasis.org>",
   "license": "ECL-2.0",


### PR DESCRIPTION
**What does this do?**
This updates the package version to 3.5.0-rc1.0 to signify the next release. It also updates the changelog.

When the PR is merged we can publish the relevant draft release https://github.com/collectionspace/cspace-public-browser.js/releases/edit/untagged-97edd7340d03ba02cdcb