### PR TITLE
DRYD-1983: Browser > Anthro > Add Material/technique description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix exhibition layout issue
 - Improve filter sidebar UX
 - Fix paragraph padding
+- Add `materialTechniqueDescription` field in anthro
 
 ## v3.3.0
 

--- a/src/config/anthro.js
+++ b/src/config/anthro.js
@@ -119,6 +119,15 @@ export default {
         field: 'collectionobjects_common:fieldCollectors',
         format: listOf(displayName),
       },
+      materialTechniqueDescription: {
+        messages: defineMessages({
+          label: {
+            id: 'detailField.materialTechniqueDescription.label',
+            defaultMessage: 'Medium',
+          },
+        }),
+        field: 'collectionobjects_anthro:materialTechniqueDescription',
+      },
     },
     groups: {
       group_collection: {
@@ -135,6 +144,7 @@ export default {
       },
       group_description: {
         fields: [
+          'materialTechniqueDescription',
           'material',
           'technique',
           'subject',


### PR DESCRIPTION
**What does this do?**
  It adds showing the `materialTechniqueDescription` for anthro config. 

**Why are we doing this? (with JIRA link)**
We had added the `materialTechniqueDescription` field in staff-ui for anthro. The field is already in fcart and is shown in public browser too. So we need to also show it in anthro public browser.

**How should this be tested? Do these changes have associated tests?**
1. Build and start the https://github.com/collectionspace/services/pull/503 services branch.
2. Configure public gateway to use `anthro_default` Elasticsearch cluster, build and run. ES should also be started.
3. Run public browser using the anthro config.
4. Run staff-ui using anthro profile and create an object record with Material/technique description. The "Publish to" field should also be set.
5. Switch to public browser and open the detail view of the just created record. In the "Description" field group, there should be the "Medium" field with the value set in step 4.

**Dependencies for merging? Releasing to production?**
It should be released along with https://github.com/collectionspace/services/pull/503 PR.

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
The Changelog has been updated.

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally.

**Have any new accessibility violations been handled?**
No new violations.
