### PR TITLE
DRYD-1606 Need ability to configure custom departmentMessage for a public browser plugin instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## v3.5.0
-- Add configurable image ordering (default: updated-at descending)
+- Add configurable image ordering (default: title ascending)
 - Fix exhibition layout issue
 - Improve filter sidebar UX
 - Fix paragraph padding
 - Add `materialTechniqueDescription` field in anthro
+- Add configurable department labels
 
 ## v3.3.0
 

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -67,3 +67,16 @@ mediaSnapshotSort: {
     title: 'asc',
 },
 ```
+
+### `departmentLabels`
+
+Optional.
+
+An object mapping department keys to display labels. Use this to override or add display names for departments in the application. The keys should match the values stored in the `responsibleDepartments` field of your data.
+
+Example:
+```
+departmentLabels: {
+    'antiquities': 'Antiquities',
+},
+```

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <script src="https://unpkg.com/react-intl@6.4.4/index.js"></script>
   <!--
     webpack dev server generates a JS bundle into memory, and updates it as files are edited.
     This bundle is served from the URL /cspacePublicBrowser.js, but it does not exist in the
@@ -38,12 +37,6 @@
 
     cspacePublicBrowser({
       gatewayUrl: 'https://core.dev.collectionspace.org/gateway/core',
-      departmentMessages: defineMessages({
-        'test-department': {
-          id: 'option.departments.test-department',
-          defaultMessage: 'Test Department',
-        },
-      }),
     });
 
     // cspacePublicBrowser({

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
+  <script src="https://unpkg.com/react-intl@6.4.4/index.js"></script>
   <!--
     webpack dev server generates a JS bundle into memory, and updates it as files are edited.
     This bundle is served from the URL /cspacePublicBrowser.js, but it does not exist in the
@@ -37,6 +38,12 @@
 
     cspacePublicBrowser({
       gatewayUrl: 'https://core.dev.collectionspace.org/gateway/core',
+      departmentMessages: defineMessages({
+        'test-department': {
+          id: 'option.departments.test-department',
+          defaultMessage: 'Test Department',
+        },
+      }),
     });
 
     // cspacePublicBrowser({

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -1,5 +1,4 @@
 import { defineMessages } from 'react-intl';
-import { getIntl } from '../intl';
 
 import {
   boolean,
@@ -16,67 +15,38 @@ import {
   valueAt,
 } from '../helpers/formatHelpers';
 
-const defaultDepartmentMessages = defineMessages({
-  antiquities: {
-    id: 'option.departments.antiquities',
-    defaultMessage: 'Antiquities',
-  },
-  'architecture-design': {
-    id: 'option.departments.architecture-design',
-    defaultMessage: 'Architecture and Design',
-  },
-  'decorative-arts': {
-    id: 'option.departments.decorative-arts',
-    defaultMessage: 'Decorative Arts',
-  },
-  ethnography: {
-    id: 'option.departments.ethnography',
-    defaultMessage: 'Ethnography',
-  },
-  herpetology: {
-    id: 'option.departments.herpetology',
-    defaultMessage: 'Herpetology',
-  },
-  'media-performance-art': {
-    id: 'option.departments.media-performance-art',
-    defaultMessage: 'Media and Performance Art',
-  },
-  'paintings-sculpture': {
-    id: 'option.departments.paintings-sculpture',
-    defaultMessage: 'Paintings and Sculpture',
-  },
-  paleobotany: {
-    id: 'option.departments.paleobotany',
-    defaultMessage: 'Paleobotany',
-  },
-  photographs: {
-    id: 'option.departments.photographs',
-    defaultMessage: 'Photographs',
-  },
-  'prints-drawings': {
-    id: 'option.departments.prints-drawings',
-    defaultMessage: 'Prints and Drawings',
-  },
-});
+const defaultDepartmentLabels = {
+  antiquities: 'Antiquities',
+  'architecture-design': 'Architecture and Design',
+  'decorative-arts': 'Decorative Arts',
+  ethnography: 'Ethnography',
+  herpetology: 'Herpetology',
+  'media-performance-art': 'Media and Performance Art',
+  'paintings-sculpture': 'Paintings and Sculpture',
+  paleobotany: 'Paleobotany',
+  photographs: 'Photographs',
+  'prints-drawings': 'Prints and Drawings',
+};
 
-const getDepartmentMessages = () => {
+const getDepartmentLabels = () => {
+  // lazy importing to avoid circular dependency
   // eslint-disable-next-line global-require
   const config = require('./index').default;
-  const customMessages = config.get('departmentMessages');
+  const customMessages = config.get('departmentLabels');
   if (customMessages) {
     // Merge custom messages with defaults
     return {
-      ...defaultDepartmentMessages,
+      ...defaultDepartmentLabels,
       ...customMessages,
     };
   }
-  return defaultDepartmentMessages;
+  return defaultDepartmentLabels;
 };
 
 const formatDepartment = (data) => {
-  const departmentMessages = getDepartmentMessages();
-  const message = departmentMessages[data];
-  return message ? getIntl().formatMessage(message) : data;
+  const departmentLabels = getDepartmentLabels();
+  const message = departmentLabels[data];
+  return message ?? data;
 };
 
 export default {

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -1,5 +1,6 @@
 import { defineMessages } from 'react-intl';
 
+import memoize from 'memoize-one';
 import {
   boolean,
   decade,
@@ -28,20 +29,20 @@ const defaultDepartmentLabels = {
   'prints-drawings': 'Prints and Drawings',
 };
 
-const getDepartmentLabels = () => {
+const getDepartmentLabels = memoize(() => {
   // lazy importing to avoid circular dependency
   // eslint-disable-next-line global-require
   const config = require('./index').default;
-  const customMessages = config.get('departmentLabels');
-  if (customMessages) {
+  const customLabels = config.get('departmentLabels');
+  if (customLabels) {
     // Merge custom messages with defaults
     return {
       ...defaultDepartmentLabels,
-      ...customMessages,
+      ...customLabels,
     };
   }
   return defaultDepartmentLabels;
-};
+});
 
 const formatDepartment = (data) => {
   const departmentLabels = getDepartmentLabels();

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -1,5 +1,6 @@
 import { defineMessages } from 'react-intl';
 import { getIntl } from '../intl';
+import config from './index'; // Import config to access merged departmentMessages
 
 import {
   boolean,
@@ -16,7 +17,7 @@ import {
   valueAt,
 } from '../helpers/formatHelpers';
 
-const departmentMessages = defineMessages({
+const defaultDepartmentMessages = defineMessages({
   antiquities: {
     id: 'option.departments.antiquities',
     defaultMessage: 'Antiquities',
@@ -59,9 +60,21 @@ const departmentMessages = defineMessages({
   },
 });
 
-const formatDepartment = (data) => {
-  const message = departmentMessages[data];
+const getDepartmentMessages = () => {
+  const customMessages = config.get('departmentMessages');
+  if (customMessages) {
+    // Merge custom messages with defaults
+    return {
+      ...defaultDepartmentMessages,
+      ...customMessages,
+    };
+  }
+  return defaultDepartmentMessages;
+};
 
+const formatDepartment = (data) => {
+  const departmentMessages = getDepartmentMessages();
+  const message = departmentMessages[data];
   return message ? getIntl().formatMessage(message) : data;
 };
 

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -1,6 +1,5 @@
 import { defineMessages } from 'react-intl';
 import { getIntl } from '../intl';
-import config from './index'; // Import config to access merged departmentMessages
 
 import {
   boolean,
@@ -61,6 +60,8 @@ const defaultDepartmentMessages = defineMessages({
 });
 
 const getDepartmentMessages = () => {
+  // eslint-disable-next-line global-require
+  const config = require('./index').default;
   const customMessages = config.get('departmentMessages');
   if (customMessages) {
     // Merge custom messages with defaults


### PR DESCRIPTION
**What does this do?**
It enables configuring department labels by using newly added `departmentLabels` configuration. The changes are:
* replaced using `defineMessages` with a plain mapping object
* added a `getDepartmentLabels` that merges default department labels with custom labels. It is used by `formatDepartment`

**Why are we doing this? (with JIRA link)**
We need the ability to configure custom departmentMessage for a public browser plugin instance: https://collectionspace.atlassian.net/browse/DRYD-1606

**How should this be tested? Do these changes have associated tests?**
1. Running cspace-ui.js locally, you will need to add a new entry in the `departments` option list configuration: https://github.com/collectionspace/cspace-ui.js/blob/b1a129ee0746fba3f790ce6a91c08bd98e5dd8ae/src/plugins/optionLists/shared.js#L77
2. Create a collection object and set the "Responsible department" field to the department added in step 1. The object should be published to public browser.
3. Then please start public browser using local gateway.
4. Confirm that in the "Department" facet, the new department label is showing up instead of the id.
5. Same for the "Department" field in the detail view 

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
Changelog and Readme have been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new accessibility violations been handled?**
No new violations
