### PR TITLE
Release 3.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@collectionspace/cspace-public-browser",
-  "version": "3.5.0-rc1.0",
+  "version": "3.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@collectionspace/cspace-public-browser",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "ECL-2.0",
       "dependencies": {
         "classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@collectionspace/cspace-public-browser",
-  "version": "3.5.0-rc1.0",
+  "version": "3.5.0",
   "description": "CollectionSpace public browser",
   "author": "Ray Lee <ray.lee@lyrasis.org>",
   "license": "ECL-2.0",


### PR DESCRIPTION
What does this do?
This updates the package version to 3.5.0 to signify the next release.

When the PR is merged we can publish the relevant draft release https://github.com/collectionspace/cspace-public-browser.js/releases/edit/untagged-415bd1841f691170477c