### PR TITLE
DRYD-2110: Public Browser > mediaSnapshotSort custom configuration not overwriting default one

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -59,13 +59,11 @@ Overrides the top-level [`filterOrder`](#filterOrder) setting, for this field.
 Overrides the top-level [`filterSize`](#filterSize) setting, for this field.
 
 ### `mediaSnapshotSort`
-Contains configuration for sorting images in object details view. The options are: `'identificationNumber'`, `'title'`, `'updatedAt'`.
+Configures the sort order for images in object details view. The value is a string in the form `'<field>:<direction>'`. Supported fields are `'identificationNumber'`, `'title'`, `'updatedAt'`. Direction is `'asc'` or `'desc'`.
 
 Default:
 ```
-mediaSnapshotSort: {
-    title: 'asc',
-},
+mediaSnapshotSort: 'updatedAt:desc',
 ```
 
 ### `departmentLabels`

--- a/src/actions/mediaActions.js
+++ b/src/actions/mediaActions.js
@@ -43,8 +43,7 @@ export const findMedia = (referenceValue, institutionId) => (dispatch, getState)
   const url = `${gatewayUrl}/es/doc/_search`;
   const referenceField = config.get('referenceField');
 
-  const sortField = Object.keys(config.get('mediaSnapshotSort'))[0];
-  const sortDirection = config.get('mediaSnapshotSort')[sortField];
+  const [sortField, sortDirection] = config.get('mediaSnapshotSort').split(':');
 
   const query = {
     _source: [referenceField, 'media_common:altText'],
@@ -53,8 +52,10 @@ export const findMedia = (referenceValue, institutionId) => (dispatch, getState)
         'collectionspace_denorm:objectCsid': [referenceValue],
       },
     },
-    sort: {
-      [sortParams[sortField]]: sortDirection,
+    ...sortField && {
+      sort: {
+        [sortParams[sortField]]: sortDirection,
+      },
     },
     size: 10000, // TODO: check if we should use scroll API instead of hardcoding the size
   };

--- a/src/actions/mediaActions.js
+++ b/src/actions/mediaActions.js
@@ -43,7 +43,11 @@ export const findMedia = (referenceValue, institutionId) => (dispatch, getState)
   const url = `${gatewayUrl}/es/doc/_search`;
   const referenceField = config.get('referenceField');
 
-  const [sortField, sortDirection] = config.get('mediaSnapshotSort').split(':');
+  const mediaSnapshotSortConfig = config.get('mediaSnapshotSort');
+  const [sortField, sortDirection] = typeof mediaSnapshotSortConfig === 'string'
+    ? mediaSnapshotSortConfig.split(':')
+    : [];
+  const validSort = sortParams[sortField] && (sortDirection === 'asc' || sortDirection === 'desc');
 
   const query = {
     _source: [referenceField, 'media_common:altText'],
@@ -52,9 +56,7 @@ export const findMedia = (referenceValue, institutionId) => (dispatch, getState)
         'collectionspace_denorm:objectCsid': [referenceValue],
       },
     },
-    sort: {
-      [sortParams[sortField]]: sortDirection,
-    },
+    ...(validSort && { sort: { [sortParams[sortField]]: sortDirection } }),
     size: 10000, // TODO: check if we should use scroll API instead of hardcoding the size
   };
 

--- a/src/actions/mediaActions.js
+++ b/src/actions/mediaActions.js
@@ -52,10 +52,8 @@ export const findMedia = (referenceValue, institutionId) => (dispatch, getState)
         'collectionspace_denorm:objectCsid': [referenceValue],
       },
     },
-    ...sortField && {
-      sort: {
-        [sortParams[sortField]]: sortDirection,
-      },
+    sort: {
+      [sortParams[sortField]]: sortDirection,
     },
     size: 10000, // TODO: check if we should use scroll API instead of hardcoding the size
   };

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -94,9 +94,7 @@ export default {
   sortField: 'collectionspace_denorm:title',
   storageKey: 'cspace-browser',
 
-  mediaSnapshotSort: {
-    title: 'asc',
-  },
+  mediaSnapshotSort: 'updatedAt:desc',
 
   searchResultImageDerivative: 'Small',
   detailImageDerivative: 'Medium',


### PR DESCRIPTION
**What does this do?**
* Changes the `mediaSnapshotSort` configuration schema from object to string. This is possible and it will not break any existing public browser configuration because it is a newly added one and the object schema is not working anyways.
* Changes the default configuration from title:ascending to updated at:descending. I am not sure why I set the default one to title, originally. I suppose because this is the default sorting in the staff UI edit-record sidebar. I think it makes more sense to set it to updated at as this was the client's requirement in the very first place.

**Why are we doing this? (with JIRA link)**
Currently the default configuration and the custom one are deep merged. When the `mediaSnapshotSort` is an object, after merging custom configuration `mediaSnapshotSort: { title: 'asc' }` and default one `mediaSnapshotSort: { updatedAt: 'desc' }`, the result is `mediaSnapshotSort: { title: 'asc' , updatedAt: 'desc' }`  and eventually the default one is being used for the request. Switching to string `mediaSnapshotSort: 'title:asc' `  resolves the issue. 

I am not sure if we can switch to shallow merge and avoid such issues in the future. But it worths investigating, I will create a follow-up task for that.

**How should this be tested? Do these changes have associated tests?**
1. Please start public browser locally. No need for a local backend. You can use dev, qa, demo environment. You just may need to apply an es reindex (`POST {host}/cspace-services/index/elasticsearchWednesday`) before, so that the new sorting options work. I had to do that for core qa.
2. Verify that the images in the detail view are sorted according to the custom configuration. 

**Dependencies for merging? Releasing to production?**
No dependencies for merging. As this fix is required by an institution through a support ticket, after merging, there will be a patch npmjs release. The institution is using the wordpress public browser version, so we don't need a whole cspace release for them.

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
The dev documentation has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally.

**Have any new accessibility violations been handled?**
No new a11y violations.