### PR TITLE
DRYD-2117: Procedure/Object > Ability to set Priority Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v3.6.0
+- Display images in the order given by the record's priority image list (`collectionspace_denorm:priorityImageList`), when available. The first priority image is used as the search result thumbnail, and the detail page gallery shows priority images without making a separate media query.
+
 ## v3.5.1
 - Fix configurable image ordering (default: updated at descending)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v3.6.0
-- Display images in the order given by the record's priority image list (`collectionspace_denorm:priorityImageList`), when available. The first priority image is used as the search result thumbnail, and the detail page gallery shows priority images without making a separate media query.
+- Display images in the order given by the record's media priority list (`collectionspace_denorm:mediaPriorityList`), when available. The first priority image is used as the search result thumbnail, and the detail page gallery shows priority images without making a separate media query.
 
 ## v3.5.1
 - Fix configurable image ordering (default: updated at descending)

--- a/src/components/detail/ImageGalleryContainer.js
+++ b/src/components/detail/ImageGalleryContainer.js
@@ -1,12 +1,28 @@
 import { connect } from 'react-redux';
+import Immutable from 'immutable';
 import ImageGallery from './ImageGallery';
 import { findMedia } from '../../actions/mediaActions';
 import { getDetailData, getMedia } from '../../reducers';
 
-const mapStateToProps = (state, ownProps) => ({
-  media: getMedia(state, ownProps.referenceValue),
-  detailData: getDetailData(state),
-});
+const mapStateToProps = (state, ownProps) => {
+  const detailData = getDetailData(state);
+
+  let media = getMedia(state, ownProps.referenceValue);
+
+  const priorityImages = detailData && detailData['collectionspace_denorm:priorityImageList'];
+
+  if (priorityImages && priorityImages.length > 0) {
+    media = (media || Immutable.Map()).set(null, Immutable.fromJS({
+      csids: priorityImages.map((image) => image.csid),
+      altTexts: priorityImages.map((image) => image.altText),
+    }));
+  }
+
+  return {
+    media,
+    detailData,
+  };
+};
 
 const mapDispatchToProps = {
   findMedia,

--- a/src/components/detail/ImageGalleryContainer.js
+++ b/src/components/detail/ImageGalleryContainer.js
@@ -9,12 +9,12 @@ const mapStateToProps = (state, ownProps) => {
 
   let media = getMedia(state, ownProps.referenceValue);
 
-  const priorityImages = detailData && detailData['collectionspace_denorm:priorityImageList'];
+  const mediaPriorityImages = detailData && detailData['collectionspace_denorm:mediaPriorityList'];
 
-  if (priorityImages && priorityImages.length > 0) {
+  if (mediaPriorityImages && mediaPriorityImages.length > 0) {
     media = (media || Immutable.Map()).set(null, Immutable.fromJS({
-      csids: priorityImages.map((image) => image.csid),
-      altTexts: priorityImages.map((image) => image.altText),
+      csids: mediaPriorityImages.map((image) => image.csid),
+      altTexts: mediaPriorityImages.map((image) => image.altText),
     }));
   }
 

--- a/src/components/search/result/SearchResultTile.jsx
+++ b/src/components/search/result/SearchResultTile.jsx
@@ -32,7 +32,8 @@ export default function SearchResultTile(props) {
   const csid = doc.get('ecm:name');
   const url = csid && `/${detailPath}/${csid}`;
   const holdingInstitutions = doc.get('collectionspace_denorm:holdingInstitutions');
-  const mediaCsid = doc.getIn(['collectionspace_denorm:mediaCsid', 0]);
+  const mediaCsid = doc.getIn(['collectionspace_denorm:priorityImageList', 0, 'csid'])
+    || doc.getIn(['collectionspace_denorm:mediaCsid', 0]);
   const referenceValue = doc.get(referenceField);
 
   let title = doc.get(tileTitleField);

--- a/src/components/search/result/SearchResultTile.jsx
+++ b/src/components/search/result/SearchResultTile.jsx
@@ -32,7 +32,7 @@ export default function SearchResultTile(props) {
   const csid = doc.get('ecm:name');
   const url = csid && `/${detailPath}/${csid}`;
   const holdingInstitutions = doc.get('collectionspace_denorm:holdingInstitutions');
-  const mediaCsid = doc.getIn(['collectionspace_denorm:priorityImageList', 0, 'csid'])
+  const mediaCsid = doc.getIn(['collectionspace_denorm:mediaPriorityList', 0, 'csid'])
     || doc.getIn(['collectionspace_denorm:mediaCsid', 0]);
   const referenceValue = doc.get(referenceField);
 

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -85,7 +85,7 @@ export default {
     'ecm:name',
     'ecm:primaryType',
     'collectionspace_denorm:mediaCsid',
-    'collectionspace_denorm:priorityImageList',
+    'collectionspace_denorm:mediaPriorityList',
     'collectionspace_denorm:title',
   ],
 

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -85,6 +85,7 @@ export default {
     'ecm:name',
     'ecm:primaryType',
     'collectionspace_denorm:mediaCsid',
+    'collectionspace_denorm:priorityImageList',
     'collectionspace_denorm:title',
   ],
 


### PR DESCRIPTION
**What does this do?**
If `priorityImageList` is set in the es response
* It populates the image gallery based on the `priorityImageList`
* It picks the first of the `priorityImageList` image for displaying in the `SearchResultTile` 

**Why are we doing this? (with JIRA link)**
Users need control over which image represents an object (and the order of the rest) in the public browser, instead of relying on the default title sort: https://collectionspace.atlassian.net/browse/DRYD-2117

**How should this be tested? Do these changes have associated tests?**
Please follow the steps in the cspace-ui PR: https://github.com/collectionspace/cspace-ui.js/pull/360

**Dependencies for merging? Releasing to production?**
Should be released along the other PRs:
https://github.com/collectionspace/cspace-ui.js/pull/360
https://github.com/collectionspace/application/pull/356
https://github.com/collectionspace/services/pull/548

**Has the [public browser documentation](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/666274513/Public+Collections+Browser) been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new accessibility violations been handled?**
no new a11y violations
